### PR TITLE
Parse top level $xref 

### DIFF
--- a/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombiner.java
+++ b/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombiner.java
@@ -87,7 +87,7 @@ public class YamlCombiner {
 		// and to make it more obvious that this isn't a valid swagger file
 
 		// this is definitely a constructive use of my weekend
-		replaceRefs((Map<Object, Object>) mergedObj, relativeDir, "");
+		mergedObj = (Map<Object, Object>) replaceRefs((Map<Object, Object>) mergedObj, relativeDir, "");
 
 		final ObjectMapper mapper = new ObjectMapper(
 			new YAMLFactory().configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)

--- a/src/test/java/com/randomnoun/maven/plugin/yamlCombine/TestCombine.java
+++ b/src/test/java/com/randomnoun/maven/plugin/yamlCombine/TestCombine.java
@@ -101,7 +101,25 @@ public class TestCombine extends  TestCase {
 
         Assert.assertEquals(expectedLines, lines);
 	}
-	
-	
+
+    // parse top level $xref to copy whole yaml
+    public void test5() throws IOException {
+        Log log = new SystemStreamLog();
+
+        YamlCombiner sc = new YamlCombiner();
+        sc.setRelativeDir(new File("src/test/resources/t5"));
+        sc.setFiles(new String[] { "input.yaml" });
+        sc.setLog(log);
+
+        StringWriter w = new StringWriter();
+        sc.combine(w);
+
+        Path expectedPath = new File("src/test/resources/t5/expected-output.yaml").toPath();
+        List<String> expectedLines = Files.readAllLines(expectedPath);
+
+        List<String> lines = Arrays.asList(w.toString().split("\n"));
+
+        Assert.assertEquals(expectedLines, lines);
+    }
 	
 }

--- a/src/test/resources/t5/expected-output.yaml
+++ b/src/test/resources/t5/expected-output.yaml
@@ -1,0 +1,46 @@
+---
+paths:
+  /thing:
+    get:
+      operationId: getThings
+      description: get all the things
+      parameters: null
+      responses:
+        200: null
+        schema:
+          type: object
+          title: getThingsOKResponse
+          properties:
+            status:
+              description: OK
+              type: string
+            thing:
+              type: array
+              items:
+                $ref: objects.yaml#/definitions/ThingObject
+    post:
+      operationId: addThing
+      description: |
+        Adds a new `Thing`.
+        * Things must be uniquely identifiable by `name`.
+        * The `id` of the thing must be empty; the newly created `id` will be returned in the response object.
+      parameters:
+        thing:
+          $ref: objects.yaml#/definitions/ThingObject
+        old-parameter:
+          description: some old parameter whose definition has changed
+        new-parameter:
+          description: the new parameter in v2 of the API that isn't in v1
+      responses:
+        200: null
+        schema:
+          type: object
+          title: getThingsOKResponse
+          properties:
+            status:
+              description: OK
+              type: string
+            thing:
+              type: array
+              items:
+                $ref: objects.yaml#/definitions/ThingObject

--- a/src/test/resources/t5/input.yaml
+++ b/src/test/resources/t5/input.yaml
@@ -1,0 +1,10 @@
+# uses paths.yaml as base and merges these changes to it
+$xref: 'paths.yaml#/'
+paths:
+  /thing:
+    post:
+      parameters:
+        old-parameter:
+          description: some old parameter whose definition has changed
+        new-parameter:
+          description: the new parameter in v2 of the API that isn't in v1

--- a/src/test/resources/t5/paths.yaml
+++ b/src/test/resources/t5/paths.yaml
@@ -1,0 +1,44 @@
+paths:
+  /thing:
+    get:
+      operationId: getThings
+      description: get all the things
+      parameters:
+      responses:
+        200:
+        schema:
+          type: object
+          title: getThingsOKResponse
+          properties:
+            status:
+              description: OK
+              type: string
+            thing:
+              type: array
+              items:
+                $ref: 'objects.yaml#/definitions/ThingObject'
+    post:
+      operationId: addThing
+      description: |
+        Adds a new `Thing`.
+        * Things must be uniquely identifiable by `name`.
+        * The `id` of the thing must be empty; the newly created `id` will be returned in the response object.
+      parameters:
+        thing:
+          $ref: 'objects.yaml#/definitions/ThingObject'
+        old-parameter:
+          description: this description will be overridden in input.yaml
+      responses:
+        200:
+        schema:
+          type: object
+          title: getThingsOKResponse
+          properties:
+            status:
+              description: OK
+              type: string
+            thing:
+              type: array
+              items:
+                $ref: 'objects.yaml#/definitions/ThingObject'
+    


### PR DESCRIPTION
I want to copy whole YAML and apply changes to it. But if `$xref` is in top level, it is correctly parsed but the result is ignored and the `$xref` stays unchanged. Seemd like a bug to me, or is there a reason to not parse top level `$xref`?