### PR TITLE
fix security issue and verbose logging passthrough

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 		<dependency>
 		    <groupId>org.yaml</groupId>
 		    <artifactId>snakeyaml</artifactId>
-		    <version>1.28</version>            
+		    <version>2.2</version>            
 		</dependency>
 
 		<!--  snakeyaml produces ugly yaml output, so we use jackson's YAMLGenerator instead 
@@ -366,7 +366,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jackson-version>2.11.3</jackson-version>
+		<jackson-version>2.17.2</jackson-version>
 	</properties>
 
 </project>

--- a/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombineMojo.java
+++ b/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombineMojo.java
@@ -187,6 +187,7 @@ public class YamlCombineMojo
 			sc.setRelativeDir(new File(fileset.getDirectory()));
 			sc.setFiles(files);
 			sc.setLog(getLog());
+			sc.setVerbose(verbose);
 			
 			fos = new FileOutputStream(destFile);
 			if (filtering) {

--- a/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombiner.java
+++ b/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombiner.java
@@ -51,7 +51,7 @@ public class YamlCombiner {
 	private Yaml newYaml() {
 		DumperOptions options = new DumperOptions();
         CustomPropertyUtils customPropertyUtils = new CustomPropertyUtils();
-        Representer customRepresenter = new Representer();
+        Representer customRepresenter = new Representer(options);
         customRepresenter.setPropertyUtils(customPropertyUtils);
         Yaml yaml = new Yaml(customRepresenter, options);
         return yaml;


### PR DESCRIPTION
When building a newer maven project, we want to avoid fasterxml with vulnerable version smaller than org.yaml:snakeyaml:2.2.
I also noticed that the verbose property is not passed through to the YamlCombiner class.