### PR TITLE
Fix: Mark finalName parameter as required in YamlCombineMojo

### DIFF
--- a/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombineMojo.java
+++ b/src/main/java/com/randomnoun/maven/plugin/yamlCombine/YamlCombineMojo.java
@@ -63,7 +63,7 @@ public class YamlCombineMojo
     /**
      * Name of the generated JAR.
      */
-    @Parameter( defaultValue = "${project.build.finalName}", readonly = true )
+    @Parameter( defaultValue = "${project.build.finalName}", required = true )
     private String finalName;
 
     /**


### PR DESCRIPTION
I want to start with a thank you for maintaining this library! It has been incredibly helpful in organizing our OpenAPI schemas.

### Issue
Our builds were generating warnings:

``` 
Parameter 'finalName' is read-only, must not be used in configuration
```

### Fix
Changed `@Parameter` annotation on `finalName` from `readonly = true` to `required = true`

I believe the `readonly` attribute was incorrectly set. This parameter should be `required` instead, as it has a default value and needs validation rather than write protection.

--



I noticed there hasn't been any activity in the last year. I hope this PR will make its way into the next release and look forward to continued maintenance of this valuable tool.